### PR TITLE
Remove non-xml output when Fits is called on a jp2

### DIFF
--- a/lib/hydra/file_characterization/characterizers/fits.rb
+++ b/lib/hydra/file_characterization/characterizers/fits.rb
@@ -4,9 +4,15 @@ module Hydra::FileCharacterization::Characterizers
   class Fits < Hydra::FileCharacterization::Characterizer
 
     protected
-    def command
-      "#{tool_path} -i \"#{filename}\""
-    end
 
+      def command
+        "#{tool_path} -i \"#{filename}\""
+      end
+
+      # Remove any residual non-XML from JHOVE
+      # See: https://github.com/harvard-lts/fits/issues/20
+      def post_process(raw_output)
+        raw_output.sub(/^READBOX seen=true\n/, '')
+      end
   end
 end

--- a/spec/lib/hydra/file_characterization/characterizers/fits_spec.rb
+++ b/spec/lib/hydra/file_characterization/characterizers/fits_spec.rb
@@ -29,6 +29,20 @@ module Hydra::FileCharacterization::Characterizers
         let(:filename) { fixture_file('archive.zip') }
         it { is_expected.to include(%(<identity format="ZIP Format" mimetype="application/zip"))}
       end
+
+      context 'when JHOVE adds non-xml' do
+        # https://github.com/harvard-lts/fits/issues/20
+        before do
+          allow(fits).to receive(:internal_call).and_return(
+            'READBOX seen=true
+<?xml version="1.0" encoding="UTF-8"?>
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="0.8.2" timestamp="15/09/14 10:00 AM">
+  <identification/></fits>')
+        end
+
+        let(:filename) { fixture_file('brendan_behan.jpeg') }
+        it { is_expected.not_to include('READBOX') }
+      end
     end
   end
 end


### PR DESCRIPTION
This is due to JHOVE putting some log messages on STDOUT
See https://github.com/harvard-lts/fits/issues/20