### PR TITLE
Handle non-xml output from FITS

### DIFF
--- a/lib/hydra/file_characterization/characterizer.rb
+++ b/lib/hydra/file_characterization/characterizer.rb
@@ -26,6 +26,10 @@ module Hydra::FileCharacterization
       @tool_path || self.class.tool_path || convention_based_tool_name
     end
 
+    def logger
+      @logger ||= activefedora_logger || Logger.new(STDERR)
+    end
+
     protected
 
       # Override this method if you want your processor to mutate the
@@ -65,6 +69,10 @@ module Hydra::FileCharacterization
         else
           internal_call
         end
+      end
+
+      def activefedora_logger
+        ActiveFedora::Base.logger if defined? ActiveFedora
       end
   end
 end

--- a/lib/hydra/file_characterization/characterizers/fits.rb
+++ b/lib/hydra/file_characterization/characterizers/fits.rb
@@ -1,5 +1,6 @@
 require 'hydra/file_characterization/exceptions'
 require 'hydra/file_characterization/characterizer'
+require 'logger'
 module Hydra::FileCharacterization::Characterizers
   class Fits < Hydra::FileCharacterization::Characterizer
 
@@ -9,10 +10,14 @@ module Hydra::FileCharacterization::Characterizers
         "#{tool_path} -i \"#{filename}\""
       end
 
-      # Remove any residual non-XML from JHOVE
+      # Remove any non-XML output that precedes the <?xml> tag
       # See: https://github.com/harvard-lts/fits/issues/20
+      #      https://github.com/harvard-lts/fits/issues/40
+      #      https://github.com/harvard-lts/fits/issues/46
       def post_process(raw_output)
-        raw_output.sub(/^READBOX seen=true\n/, '')
+        md = /\A(.*)(<\?xml.*)\Z/m.match(raw_output)
+        logger.warn "FITS produced non-xml output: \"#{md[1].chomp}\"" unless md[1].empty?
+        md[2]
       end
   end
 end

--- a/spec/lib/hydra/file_characterization/characterizers/fits_spec.rb
+++ b/spec/lib/hydra/file_characterization/characterizers/fits_spec.rb
@@ -36,6 +36,7 @@ module Hydra::FileCharacterization::Characterizers
       subject { fits.call }
 
       before do
+        expect(fits.logger).to receive(:warn)
         allow(fits).to receive(:internal_call).and_return(
           'READBOX seen=true
 <?xml version="1.0" encoding="UTF-8"?>
@@ -45,6 +46,23 @@ module Hydra::FileCharacterization::Characterizers
 
       let(:filename) { fixture_file('brendan_behan.jpeg') }
       it { is_expected.not_to include('READBOX') }
+    end
+
+    context "when FITS itself adds non-xml" do
+      # https://github.com/harvard-lts/fits/issues/46
+      subject { fits.call }
+
+      before do
+        expect(fits.logger).to receive(:warn)
+        allow(fits).to receive(:internal_call).and_return(
+          '2015-10-15 17:14:25,761 ERROR [main] ToolBelt:79 - Thread 1 error initializing edu.harvard.hul.ois.fits.tools.droid.Droid: edu.harvard.hul.ois.fits.exceptions.FitsToolException  Message: DROID cannot run under Java 8
+<?xml version="1.0" encoding="UTF-8"?>
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="0.8.2" timestamp="15/09/14 10:00 AM">
+<identification/></fits>')
+      end
+
+      let(:filename) { fixture_file('brendan_behan.jpeg') }
+      it { is_expected.not_to include('FitsToolException') }
     end
   end
 end


### PR DESCRIPTION
This logs a warning with whatever messages preceed the `<?xml>` header
See https://github.com/harvard-lts/fits/issues/46